### PR TITLE
Fix agent deploy resolving to wrong instance when names match

### DIFF
--- a/src/commands/agent/deploy.ts
+++ b/src/commands/agent/deploy.ts
@@ -121,6 +121,10 @@ export function selectTargetAgent(
 		}
 	}
 
+	if (instance.id !== undefined || instance.instanceName) {
+		return undefined;
+	}
+
 	if (matchingByName.length === 1 && matchingByName[0].id !== undefined) {
 		return matchingByName[0];
 	}

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -215,4 +215,16 @@ describe("Agent Config Utilities", () => {
 
 		expect(selected).toBeUndefined();
 	});
+
+	it("should not select a single name match from a different instance", () => {
+		const selected = selectTargetAgent(
+			[
+				{ id: 1, agentName: "simple-claude-agent", machineInstanceId: 11 },
+			],
+			"simple-claude-agent",
+			{ id: 12, instanceName: "ts-agent-claude-14" }
+		);
+
+		expect(selected).toBeUndefined();
+	});
 });


### PR DESCRIPTION
### Motivation
- Deploying with `--instance` should never update an agent on a different machine just because there is exactly one agent with the same name in the project, so selection must respect the explicit instance argument.

### Description
- Tighten `selectTargetAgent` in `src/commands/agent/deploy.ts` to return `undefined` when an explicit `instance.id` or `instance.instanceName` was provided but no agent matches that instance, preventing a fallback to a single same-name agent on another instance.
- Add a regression test in `test/agent.test.ts` that verifies a single same-name agent on a different instance is not selected when an explicit instance is provided.

### Testing
- Ran `npx vitest run test/agent.test.ts` and the test suite passed (13 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab334bd16083248a27327c9555f0e8)